### PR TITLE
Iniciada a implementação do struct_to_byte_array - Contem Bugs

### DIFF
--- a/comm.c
+++ b/comm.c
@@ -1,5 +1,6 @@
 #include "comm.h"
 
+//---Setters---
 void set_mode(package * pkg, int32_t mode){
 	pkg->mode = mode;	
 }
@@ -60,6 +61,7 @@ void set_is_open(package * pkg, int32_t is_open){
 	pkg->is_open = is_open;
 }
 
+//---Getters---
 int32_t get_mode(package pkg){
 	return pkg.mode;
 }
@@ -120,6 +122,7 @@ int32_t get_is_open(package pkg){
 	return pkg.is_open;
 }
 
+//--Utils--
 void print_pkg(package pkg){
 	printf("mode: %d\n", get_mode(pkg));
 	printf("gps_isValid: %d\n", get_gps_isValid(pkg));
@@ -138,16 +141,64 @@ void print_pkg(package pkg){
 	printf("is_open %d\n", get_is_open(pkg));
 }
 
+//Prints package data using struct
+void print_struct_pkg(package pkg){
+	printf("mode: %d\n", get_mode(pkg));
+	printf("gps_isValid: %d\n", get_gps_isValid(pkg));
+	printf("gps_lat: %d\n", get_gps_lat(pkg));
+	printf("gps_lng: %d\n", get_gps_lng(pkg));
+	printf("gps_hdop_value: %d\n", get_gps_hdop_value(pkg));
+	printf("gps_satellites_value %d\n", get_gps_satellites_value(pkg));
+	printf("gps_altitude_meters %d\n", get_gps_altitude_meters(pkg));
+	printf("gps_course_deg %d\n", get_gps_course_deg(pkg));
+	printf("gps_speed_kmph %d\n", get_gps_speed_kmph(pkg));
+	printf("bpm_temperature %d\n", get_bpm_temperature(pkg));
+	printf("bpm_altitude %d\n", get_bpm_altitude(pkg));
+	printf("bpm_pressure %d\n", get_bpm_pressure(pkg));
+	printf("status_sd %d\n", get_status_sd(pkg));
+	printf("bar_speed %d\n", get_bar_speed(pkg));
+	printf("is_open %d\n", get_is_open(pkg));
+}
+
+//Prints array package
+void print_array_pkg(uint8_t* pkg_data){
+	
+	int8_t i;
+	
+	for(i = 0; i < PACKAGE_SIZE; i++){
+		printf("%d", pkg_data[i]);
+	}
+	printf("\n");
+	
+	return;
+}
+
+//Converts a package to byte array
+uint8_t* struct_to_byte_array(package pkg){
+	
+	//Memory allocation
+	uint8_t *ptrByte  = (uint8_t *) malloc(sizeof(pkg));
+	
+	//casts a pointer to byte from pkg address
+	ptrByte  = (uint8_t *) &pkg;
+	
+	return ptrByte;
+	
+}
+
 int main(){
 
 	package pkg;
-
+	uint8_t* pkg_data;
+	
+	printf("Size of pkg : %d\n", sizeof(pkg));
+	
 	//Package initialization
-	set_mode(&pkg, 1);
-	set_gps_isValid(&pkg, 1);
-	set_gps_lat(&pkg, 1);
-	set_gps_lng(&pkg, 1);
-	set_gps_hdop_value(&pkg, 1);
+	set_mode(&pkg, 3);
+	set_gps_isValid(&pkg, 6);
+	set_gps_lat(&pkg, 2);
+	set_gps_lng(&pkg, 5);
+	set_gps_hdop_value(&pkg, 3);
 	set_gps_satellites_value(&pkg, 1);
 	set_gps_altitude_meters(&pkg, 1);
 	set_gps_course_deg(&pkg, 1);
@@ -156,11 +207,15 @@ int main(){
 	set_bpm_altitude(&pkg, 1);
 	set_bpm_pressure(&pkg, 1);
 	set_status_sd(&pkg, 1);
-	set_bar_speed(&pkg, 1);
-	set_is_open(&pkg, 1);
+	set_bar_speed(&pkg, 4);
+	set_is_open(&pkg, 257);
+	
+	pkg_data = struct_to_byte_array(pkg);
 	
 	//Show package data
-	print_pkg(pkg);
+	print_struct_pkg(pkg);
+	printf("Data Array : ");
+	print_array_pkg(pkg_data);
 
 	return 0;
 }

--- a/comm.h
+++ b/comm.h
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <inttypes.h>
 
+#define PACKAGE_SIZE 60 
+
 typedef struct package{
 	int32_t mode;
 	int32_t gps_isValid;
@@ -20,7 +22,7 @@ typedef struct package{
 	int32_t is_open;
 }package;
 
-//Setters
+//---Setters---
 void set_mode(package *, int32_t);
 
 void set_gps_isValid(package *, int32_t);
@@ -51,7 +53,7 @@ void set_bar_speed(package *, int32_t);
 
 void set_is_open(package *, int32_t);
 
-//Getters
+//---Getters---
 int32_t get_mode(package);
 
 int32_t get_gps_isValid(package);
@@ -82,5 +84,19 @@ int32_t get_bar_speed(package);
 
 int32_t get_is_open(package);
 
-//Prints package data
-void print_pkg(package);
+int8_t get_parity_bit(package);
+
+
+//---Utils---
+
+//Prints package data using struct
+void print_struct_pkg(package);
+
+//Prints array package
+void print_array_pkg(uint8_t*);
+
+//Converts a package to byte array
+uint8_t* struct_to_byte_array(package);
+
+
+


### PR DESCRIPTION
Iniciada a implementação do código que converte a Struct do pacote para um Array de tipo uint8_t, um array de bytes.

Por algum motivo, quando eu tento printar os dados dos dois primeiros elementos do pacote, o programa printa lixo. O resto dos dados são printados corretamente.